### PR TITLE
外観 / 微調整

### DIFF
--- a/AppLauncher/App.xaml
+++ b/AppLauncher/App.xaml
@@ -7,7 +7,7 @@
     <Application.Resources>
         <SolidColorBrush x:Key="DarkBgBrush" Color="#333344" />
         <SolidColorBrush x:Key="ForegroundBrush" Color="WhiteSmoke" />
-        <sys:Double x:Key="BasicFontSize">16.0</sys:Double>
+        <sys:Double x:Key="BasicFontSize">15.0</sys:Double>
 
         <Style TargetType="TextBox">
             <Setter Property="FontSize" Value="{StaticResource BasicFontSize}" />

--- a/AppLauncher/Views/MainWindow.xaml
+++ b/AppLauncher/Views/MainWindow.xaml
@@ -9,8 +9,8 @@
     xmlns:prism="http://prismlibrary.com/"
     xmlns:viewModels="clr-namespace:AppLauncher.ViewModels"
     Title="{Binding Title}"
-    Width="600"
-    Height="400"
+    Width="800"
+    Height="300"
     d:DataContext="{d:DesignInstance viewModels:MainWindowViewModel}"
     prism:ViewModelLocator.AutoWireViewModel="True"
     Background="{StaticResource DarkBgBrush}"
@@ -107,7 +107,7 @@
             </ListBox.ItemContainerStyle>
         </ListBox>
 
-        <Grid Grid.Row="1" Margin="0,5">
+        <Grid Grid.Row="1" Margin="0,5,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition />

--- a/AppLauncher/Views/MainWindow.xaml
+++ b/AppLauncher/Views/MainWindow.xaml
@@ -122,8 +122,11 @@
                 Grid.Column="2"
                 Width="100"
                 HorizontalAlignment="Right"
-                Content="Registration"
-                DockPanel.Dock="Right" />
+                DockPanel.Dock="Right">
+                <Button.Content>
+                    <TextBlock Foreground="Black" Text="Registration" />
+                </Button.Content>
+            </Button>
         </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
主な変更点は以下
 - 行ごとに表示できる内容が多いほうが都合が良いため、ウィンドウのサイズを横を広く、縦を短く変更した。
 - 統一感がなくて見た目が悪かったため、画面下部のパーツのマージンを微調整した。
 - 画面下部のボタンの背景色と文字色が同化していた件に対処した。

