### PR TITLE
ワークフローの更新

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -4,22 +4,43 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Target branch for manual runs'
+        required: true
+        default: 'main'
 
 jobs:
   check-version:
     runs-on: ubuntu-latest
     steps:
+      - name: Set target branch
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TARGET_BRANCH="${{ github.event.inputs.target_branch }}"
+          else
+            TARGET_BRANCH="main"
+          fi
+          echo "TARGET_BRANCH=$TARGET_BRANCH" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Fetch all branches
         run: git fetch --all
+
       - name: Check for file changes
         run: |
-          if ! git diff --name-only origin/main | grep -q "TextWrapper.cs"; then
-          # 現在のブランチとリモートの main ブランチとの差分を確認。ファイル名 "TextWrapper.cs" が含まれるか調べる。
+          if [ "$TARGET_BRANCH" != "main" ]; then
+            echo "TARGET_BRANCH=$TARGET_BRANCH"
+            echo "Target branch is not main. Skipping file check."
+            exit 0
+          fi
 
-          echo "TextWrapper.cs has not been changed. Rejecting PR."
-          exit 1  # 指定したファイル名が含まれない場合、エラーのコード (1) を返す
+          if ! git diff --name-only origin/main | grep -q "TextWrapper.cs"; then
+            echo "TextWrapper.cs has not been changed. Rejecting PR."
+            exit 1
           else
-          echo "TextWrapper.cs has been changed. Proceeding with PR."
+            echo "TextWrapper.cs has been changed. Proceeding with PR."
           fi

--- a/AppLauncher/App.xaml
+++ b/AppLauncher/App.xaml
@@ -5,6 +5,7 @@
     xmlns:prism="http://prismlibrary.com/"
     xmlns:sys="clr-namespace:System">
     <Application.Resources>
+        <SolidColorBrush x:Key="LightBgBrush" Color="#444455" />
         <SolidColorBrush x:Key="DarkBgBrush" Color="#333344" />
         <SolidColorBrush x:Key="ForegroundBrush" Color="WhiteSmoke" />
         <sys:Double x:Key="BasicFontSize">15.0</sys:Double>

--- a/AppLauncher/Views/MainWindow.xaml
+++ b/AppLauncher/Views/MainWindow.xaml
@@ -38,6 +38,7 @@
 
         <ListBox
             Grid.Row="0"
+            AlternationCount="2"
             Background="{StaticResource DarkBgBrush}"
             ItemsSource="{Binding ApplicationListViewModel.ApplicationInfos}"
             SelectedItem="{Binding ApplicationListViewModel.SelectedItem}">
@@ -86,6 +87,13 @@
 
             <ListBox.ItemContainerStyle>
                 <Style TargetType="ListBoxItem">
+
+                    <Style.Triggers>
+                        <Trigger Property="ItemsControl.AlternationIndex" Value="0">
+                            <Setter Property="Background" Value="{StaticResource LightBgBrush}" />
+                        </Trigger>
+                    </Style.Triggers>
+
                     <Setter Property="ContextMenu">
                         <Setter.Value>
                             <ContextMenu>


### PR DESCRIPTION
間違ったブランチをマージ先に指定して PR を出したときに、バージョン確認用のワークフローが失敗する。
失敗することは問題ないが、現状だと正しいブランチに設定し直した後、失敗したワークフローを成功状態にできない。

この PR で、develop を対象にした手動マージの場合は、その時点でチェックをパスするようにした、
これによってワークフローを後から成功状態にできる。